### PR TITLE
Feature gate individual algorithms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,15 @@ readme = "README.md"
 keywords = ["pitch", "audio", "fft", "yin", "pyin"]
 categories = ["multimedia::audio", "algorithms"]
 
+[features]
+default = ["yin", "pyin"]
+yin = []
+pyin = ["dep:bio", "dep:ndarray"]
+
 [dependencies]
 realfft = "3.4.0"
-bio = "2.0.3"
-ndarray = "0.16.1"
+bio = { version = "2.0.3", optional = true }
+ndarray = { version = "0.16.1", optional = true }
 
 [dev-dependencies]
 rstest = "0.23.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,17 @@
 mod core;
 mod fft;
+#[cfg(feature = "pyin")]
 mod hmm;
+#[cfg(feature = "pyin")]
 mod pyin;
+#[cfg(feature = "yin")]
 mod yin;
 
 use std::ops::Range;
 
+#[cfg(feature = "pyin")]
 pub use pyin::Pyin;
+#[cfg(feature = "yin")]
 pub use yin::Yin;
 
 pub trait PitchDetector {


### PR DESCRIPTION
Thank you for creating this library.

I only need the YIN algorithm. The pYIN algorithm requires dependencies that aren't needed when using only the YIN algorithm. Especially the `bio` dependency adds a lot of transitive dependencies.

This PR places both algorithms behind feature gates in order to make the unneeded dependencies optional.

Here are some comparisons between building the different algorithms:

| Enabled features | Dependency count | Build time (from scratch) |
| ---------------- | ---------------- | ------------------------- |
| yin              |               15 |                     6.9 s |
| pin              |              126 |                    17.4 s |